### PR TITLE
fix(npm): bump passport to 0.6.0

### DIFF
--- a/lib/policies/oauth2/site.js
+++ b/lib/policies/oauth2/site.js
@@ -5,9 +5,11 @@ const path = require('path');
 
 module.exports.loginForm = (request, response) => response.render(path.join(__dirname, 'views/login'));
 
-module.exports.login = passport.authenticate('local', { successReturnToOrRedirect: '/', failureRedirect: '/login' });
+module.exports.login = passport.authenticate('local', { successReturnToOrRedirect: '/', failureRedirect: '/login', keepSessionInfo: true });
 
-module.exports.logout = (request, response) => {
-  request.logout();
-  response.redirect('/');
+module.exports.logout = (request, response, next) => {
+  request.logout(function(err) {
+    if (err) { return next(err); }
+    response.redirect('/');
+  });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "minimatch": "^5.1.0",
         "oauth2orize": "^1.11.1",
         "parent-require": "^1.0.0",
-        "passport": "^0.4.1",
+        "passport": "^0.6.0",
         "passport-http": "0.3.0",
         "passport-http-bearer": "1.0.1",
         "passport-jwt": "^4.0.0",
@@ -8379,15 +8379,20 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-http": {
@@ -19443,12 +19448,13 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
       }
     },
     "passport-http": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "minimatch": "^5.1.0",
     "oauth2orize": "^1.11.1",
     "parent-require": "^1.0.0",
-    "passport": "^0.4.1",
+    "passport": "^0.6.0",
     "passport-http": "0.3.0",
     "passport-http-bearer": "1.0.1",
     "passport-jwt": "^4.0.0",


### PR DESCRIPTION
Bumped `v0.4.1` to `v0.6.0`, followed this [post](https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d).

_Code changes:_
- added `keepSessionInfo: true` option in `passport.authenticate`.
- updated `request.logout`, to be:
```
req.logout(function(err) {
  if (err) { return next(err); }
  res.redirect('/');
});
```

This PR resolves session regeneration [vulnerability issue](https://github.com/ratehub/ratehub-express-gateway/security/dependabot/20).