### PR TITLE
fix: configure npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
           @semantic-release/npm@8.x @semantic-release/github@8.x \
           @semantic-release/release-notes-generator@10.x
         npm ci
+    - name: Configure an NPM registry
+      run: npm config set registry https://packagecloud.io/ratehub/npm/npm/
     - name: Configure read only access to a private NPM registry
       env:
         GITHUB_TOKEN: ${{ secrets.GH_RATEHUB_MACHINE_TOKEN }}


### PR DESCRIPTION
Set npm registry to fix [release workflow](https://github.com/ratehub/ratehub-express-gateway/actions/runs/3114550558/jobs/5050515004).