### PR TITLE
ci(release): fix git-push auth and bump action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RATEHUB_MACHINE_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: "14.X"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       !contains(github.event.head_commit.message, '[skip release]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_RATEHUB_MACHINE_TOKEN }}
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.X"
           registry-url: https://packagecloud.io/ratehub/npm/npm/


### PR DESCRIPTION
## Summary
Follow-up to #28. Two unrelated CI fixes bundled because they touch the same file.

### 1. Fix git-push auth (the actual blocker)
The release workflow for #28 failed at the `@semantic-release/git` prepare step with `EGITNOPERMISSION` ([run](https://github.com/ratehub/ratehub-express-gateway/actions/runs/26527029472)), so `1.17.2` never published.

`actions/checkout` configures git auth with the auto-provisioned `GITHUB_TOKEN`, which the runner reports as `Contents: read`. semantic-release's `GITHUB_TOKEN` env var (the machine token, used for API calls) is not what `git push` uses — git push uses whatever credentials checkout wrote into `.git/config`.

Pass `GH_RATEHUB_MACHINE_TOKEN` to `actions/checkout` so `git push` uses the same token semantic-release uses for API calls.

### 2. Bump action versions
`actions/checkout@v2` (2020) and `actions/setup-node@v1` (2019) are years past EOL. Bumped to `checkout@v5` and `setup-node@v4`. Node version left at `14.X` for now — semantic-release@18 still works there and bumping Node is a separate concern.

## Test plan
- [ ] Merge → release workflow re-runs → publishes `@ratehub/ratehub-express-gateway@1.17.2` to PackageCloud and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)