### PR TITLE
feat(admin-api): exhaust SCAN cursor server-side in user/application findAll

### DIFF
--- a/docs/admin-list-scaling.md
+++ b/docs/admin-list-scaling.md
@@ -9,11 +9,18 @@ keys are extremely sparse, so most batches come back with **zero matches and a
 non-zero cursor** — meaning "I looked at 100 slots, none matched, keep going."
 
 The previous bug was that `findAll` overwrote that cursor with `0`, making the
-endpoint falsely report "iteration complete." That was fixed by preserving the
-real cursor (see `lib/services/consumers/user.dao.js` and `application.dao.js`).
+endpoint falsely report "iteration complete." It was first fixed by preserving
+the real cursor so paginating clients could walk to completion. That left a
+secondary UX problem — a single `GET /users` returns at most one COUNT-sized
+batch, so a busy Redis required dozens of round trips to surface a handful of
+users. The current `findAll` therefore loops `SCAN` server-side until the
+cursor returns to `0` and returns every match in one response, with
+`nextKey: 0`. See `lib/services/consumers/user.dao.js` and
+`application.dao.js`.
 
-What's left is the underlying scaling problem the fix exposes: pagination now
-*works*, but it's slow.
+What's left is the underlying scaling problem this hides: each `GET /users`
+call still blocks on a full keyspace traversal (`O(total Redis keys)`),
+because there is no index of users separate from the keyspace itself.
 
 ## Measured behavior on a real Redis
 
@@ -83,13 +90,13 @@ safest sequence is:
 For a single-instance gateway you can skip step 1 and just run the backfill
 right before the switch, accepting a few seconds of empty-list responses.
 
-### Alternative considered: server-side SCAN loop
+### Current behavior: server-side SCAN loop
 
-Have `findAll` iterate SCAN internally until cursor returns to 0 and return
-everything in one call. Simpler than an index — no insert/remove changes, no
-backfill — but every list request blocks on a full keyspace traversal. Fine for
-small deployments, terrible as the Redis grows. Use only if maintaining an
-index is genuinely out of scope.
+`findAll` iterates SCAN internally until the cursor returns to 0 and returns
+everything in one response. Simpler than an index — no insert/remove changes,
+no backfill — but every list request blocks on a full keyspace traversal.
+Fine for the current Redis size; the index migration above is the right move
+once admin-API latency or Redis load from these endpoints becomes a problem.
 
 ### Alternative considered: bump default COUNT
 

--- a/lib/services/consumers/application.dao.js
+++ b/lib/services/consumers/application.dao.js
@@ -53,20 +53,18 @@ dao.update = function (id, props) {
     });
 };
 
-dao.findAll = function ({ start = 0, count = '100' } = {}) {
+dao.findAll = async function ({ start = 0, count = '100' } = {}) {
   const key = appHashKey('');
-  return db.scan(start, 'MATCH', `${key}*`, 'COUNT', count).then(resp => {
-    const nextKey = parseInt(resp[0], 10);
-    const appKeys = resp[1];
-    if (!appKeys || appKeys.length === 0) return Promise.resolve({ apps: [], nextKey });
-    const promises = appKeys.map(key => db.hgetall(key));
-    return Promise.all(promises).then(apps => {
-      return {
-        apps,
-        nextKey
-      };
-    });
-  });
+  const appKeys = [];
+  let cursor = String(start);
+  do {
+    const [next, batch] = await db.scan(cursor, 'MATCH', `${key}*`, 'COUNT', count);
+    cursor = next;
+    if (batch && batch.length) appKeys.push(...batch);
+  } while (cursor !== '0');
+  if (appKeys.length === 0) return { apps: [], nextKey: 0 };
+  const apps = await Promise.all(appKeys.map(k => db.hgetall(k)));
+  return { apps, nextKey: 0 };
 };
 
 dao.find = function (appName) {

--- a/lib/services/consumers/user.dao.js
+++ b/lib/services/consumers/user.dao.js
@@ -29,20 +29,18 @@ dao.getUserById = function (userId) {
     });
 };
 
-dao.findAll = function ({ start = 0, count = '100' } = {}) {
+dao.findAll = async function ({ start = 0, count = '100' } = {}) {
   const key = config.systemConfig.db.redis.namespace.concat('-', userNamespace).concat(':');
-  return db.scan(start, 'MATCH', `${key}*`, 'COUNT', count).then(resp => {
-    const nextKey = parseInt(resp[0], 10);
-    const userKeys = resp[1];
-    if (!userKeys || userKeys.length === 0) return Promise.resolve({ users: [], nextKey });
-    const promises = userKeys.map(key => db.hgetall(key));
-    return Promise.all(promises).then(users => {
-      return {
-        users,
-        nextKey
-      };
-    });
-  });
+  const userKeys = [];
+  let cursor = String(start);
+  do {
+    const [next, batch] = await db.scan(cursor, 'MATCH', `${key}*`, 'COUNT', count);
+    cursor = next;
+    if (batch && batch.length) userKeys.push(...batch);
+  } while (cursor !== '0');
+  if (userKeys.length === 0) return { users: [], nextKey: 0 };
+  const users = await Promise.all(userKeys.map(k => db.hgetall(k)));
+  return { users, nextKey: 0 };
 };
 
 dao.find = function (username) {


### PR DESCRIPTION
## Summary
Follow-up to #28. With the cursor-preservation fix from that PR, paginating clients can finally walk to completion — but on a busy Redis a single `GET /users` still only returns one COUNT-sized batch, so the admin UI / `eg users list` has to make dozens of round trips to surface a handful of users.

Observed live on ratehub's dev Redis with 4 users:

```
SCAN 0      MATCH 'EG-user:*' COUNT 100  →  cursor 214016, []
SCAN 214016 MATCH 'EG-user:*' COUNT 100  →  cursor 20992,  []
SCAN 20992  MATCH 'EG-user:*' COUNT 100  →  cursor 259584, []
SCAN 259584 MATCH 'EG-user:*' COUNT 100  →  cursor 203008, []
...
```

After this PR, `findAll` loops SCAN server-side until the cursor returns to `0`, accumulates all matches, and returns everything in one response with `nextKey: 0`. Caller still passes `{ start, count }` — `start` lets a caller resume from an earlier cursor (e.g. a client that timed out mid-walk), `count` tunes batch size.

This is a **server-side** behavior change: the response shape is the same, the response is just bigger and `nextKey` is always 0.

## Trade-off

Each `GET /users` / `GET /apps` / `GET /credentials` request now blocks on a full keyspace traversal (`O(total Redis keys)`). Fine for the current Redis size and the rare admin-API call cadence; not great if either grows. The proper long-term fix is the `EG-users:index` sorted-set pattern documented in [`docs/admin-list-scaling.md`](./docs/admin-list-scaling.md), which makes `findAll` `O(N_entities)` independent of total keyspace size.

## Test plan
- [x] Verified against a polluted Redis (5000 noise keys + 4 EG-user:*): single `findAll()` call returns all 4 users with `nextKey: 0`.
- [x] Resume-from-cursor still works (`findAll({ start: 1000 })` returns matches from that point onwards).
- [ ] Existing mocha tests (`test/services/users.test.js`, `applications.test.js`) — they exercise `findAll()` on a fresh DB and check `users.length === 1` and `should.exist(data.nextKey)`, both of which still hold (`nextKey: 0` exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)